### PR TITLE
Fix goto arg types

### DIFF
--- a/src/lib/UrlProvider.d.ts
+++ b/src/lib/UrlProvider.d.ts
@@ -5,7 +5,7 @@ export interface UseUrlQuery {
 export interface UseUrlReturn {
     context: string | string[];
     query: UseUrlQuery;
-    goto: (path: string, newQuery?: UseUrlQuery, replace?: boolean) => void;
+    goto: (path?: string | null, newQuery?: UseUrlQuery | null, replace?: boolean) => void;
 }
 interface UrlProviderProps {
     children: ReactNode;

--- a/src/lib/UrlProvider.js
+++ b/src/lib/UrlProvider.js
@@ -7,12 +7,12 @@ export function UrlProvider({ children }) {
     const goto = (path, Q, replaceQuery = false) => {
         let newQuery;
         if (replaceQuery) {
-            newQuery = Q;
+            newQuery = Q ?? null;
         }
         else {
             newQuery = {
                 ...query,
-                ...Q,
+                ...(Q ?? {}),
             };
         }
         const queryString = newQuery ? new URLSearchParams(newQuery).toString() : '';

--- a/src/lib/UrlProvider.tsx
+++ b/src/lib/UrlProvider.tsx
@@ -8,7 +8,7 @@ export interface UseUrlQuery {
 export interface UseUrlReturn {
   context: string | string[]
   query: UseUrlQuery
-  goto: (path: string, newQuery?: UseUrlQuery, replace?: boolean) => void
+  goto: (path?: string | null, newQuery?: UseUrlQuery | null, replace?: boolean) => void
 }
 
 const UrlContext = createContext<UseUrlReturn | undefined>(undefined)
@@ -21,14 +21,18 @@ export function UrlProvider({ children }: UrlProviderProps) {
   const [context, setContext] = useState<string | string[]>('')
   const [query, setQuery] = useState<UseUrlQuery>({})
 
-  const goto = (path: string, Q?: UseUrlQuery, replaceQuery: boolean = false) => {
+  const goto = (
+    path?: string | null,
+    Q?: UseUrlQuery | null,
+    replaceQuery: boolean = false,
+  ) => {
     let newQuery
     if (replaceQuery) {
-      newQuery = Q
+      newQuery = Q ?? null
     } else {
       newQuery = {
         ...query,
-        ...Q,
+        ...(Q ?? {}),
       }
     }
 


### PR DESCRIPTION
## Summary
- make `goto` parameters optional in `UrlProvider`
- update JS and type definitions accordingly

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6846d43cdb388327a08530caf71cd3a1