### PR TITLE
Fix import alias usage in package

### DIFF
--- a/package/src/hook/useWait.ts
+++ b/package/src/hook/useWait.ts
@@ -1,5 +1,5 @@
 import {useEffect, useState} from 'react'
-import useTimeout from '@/hook/useTimeout'
+import useTimeout from './useTimeout'
 
 
 export default function useWait(

--- a/package/src/hook/useWebSocket.ts
+++ b/package/src/hook/useWebSocket.ts
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from 'react'
-import useInterval from '@/hook/useInterval'
+import useInterval from './useInterval'
 
 interface WebSocketState {
   [key: string]: any

--- a/package/src/ux/PictureInPicture.tsx
+++ b/package/src/ux/PictureInPicture.tsx
@@ -1,6 +1,6 @@
 import { useRef } from 'react'
 import type { ReactNode } from 'react'
-import usePictureInPicture from '@/hook/usePictureInPicture'
+import usePictureInPicture from '../hook/usePictureInPicture'
 
 
 type PictureInPictureProps = {


### PR DESCRIPTION
## Summary
- remove `@` alias imports in package source

## Testing
- `npm test --silent --prefix package` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684703b7efb48327980dbaa68ec0831b